### PR TITLE
More features in blocking mode, ulid() is created per feed

### DIFF
--- a/go/changefeed/generated_test.go
+++ b/go/changefeed/generated_test.go
@@ -3,9 +3,10 @@ package changefeed
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCreateStateTable(t *testing.T) {
@@ -76,8 +77,8 @@ func TestCreateLockProcedure(t *testing.T) {
 	require.NoError(t, fixture.AdminDB.QueryRow(`select [changefeed].sql_create_lock_procedure(object_id('myservice.MultiPK'), 'changefeed')`).Scan(&sql))
 	fmt.Println(sql)
 	// Simply check that generated SQL compiles
-	//_, err := fixture.AdminDB.ExecContext(context.Background(), sql)
-	//require.NoError(t, err)
+	_, err := fixture.AdminDB.ExecContext(context.Background(), sql)
+	require.NoError(t, err)
 }
 
 func TestRoleOutboxReader(t *testing.T) {


### PR DESCRIPTION
* Remove `changefeed.ulid()`. However, support for such functions already created is *kept*, they will still work, but new ones will not be created in new installations.
* Instead, `changefeed.[ulid:yourschema.YourTable]()` is made available
* Also, `changefeed.[lock:*]` gets some new arguments, and if you only need a single ulid you can just grab it from there

These changes are done because the previous interface didn't allow writing to more than one feed in one database transaction; this quickly broke down in real world usage.